### PR TITLE
Do not render table of contents if no headers were present

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -19,7 +19,7 @@ import { Seo } from "../src/Seo";
 import { DEFAULT_URL } from "../content/metadata";
 import { formatDate, isElementNode } from "../src/utils";
 import { serializePost } from "../src/serializePost";
-import React, { ElementType, useEffect } from "react";
+import React, { ElementType } from "react";
 import { createMachine } from "xstate";
 import { useMachine } from "@xstate/react";
 
@@ -102,7 +102,6 @@ const PostPage: React.FC<{
         document.documentElement.style.scrollBehavior = "smooth";
       },
       disableSmoothScroll: () => {
-        console.log("disableSmoothScroll");
         document.documentElement.style.scrollBehavior = "auto";
       },
     },
@@ -128,27 +127,29 @@ const PostPage: React.FC<{
       />
       <Layout
         posts={posts}
-        renderSidebar={() => (
-          <Flex
-            flexDirection="column"
-            alignItems="flex-start"
-            position="sticky"
-            bottom="4"
-            gap="6"
-          >
-            <Button
-              justifyContent="center"
-              aria-label="scroll to top"
-              leftIcon={<ArrowUpIcon />}
-              as="a"
-              textDecoration="none"
-              href="#"
+        renderSidebar={() =>
+          mdx.toc ? (
+            <Flex
+              flexDirection="column"
+              alignItems="flex-start"
+              position="sticky"
+              bottom="4"
+              gap="6"
             >
-              Scroll to top
-            </Button>
-            <TOC toc={mdx.toc} />
-          </Flex>
-        )}
+              <Button
+                justifyContent="center"
+                aria-label="scroll to top"
+                leftIcon={<ArrowUpIcon />}
+                as="a"
+                textDecoration="none"
+                href="#"
+              >
+                Scroll to top
+              </Button>
+              <TOC toc={mdx.toc} />
+            </Flex>
+          ) : null
+        }
       >
         <Box
           as="article"
@@ -240,7 +241,13 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async (ctx) => {
   const posts = await getAllPosts();
-  const post = posts.find((post) => post.slug === ctx.params.slug);
+  const post = posts.find((post) => post.slug === ctx.params?.slug);
+
+  if (!post) {
+    return {
+      notFound: true,
+    };
+  }
 
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { Seo } from "../src/Seo";
 import { formatDate } from "../src/utils";
 import { generateFeed } from "../src/feed";
+import React from "react";
 
 const Home: NextPage<{ posts: Post[] }> = ({ posts }) => {
   return (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -37,40 +37,43 @@ const LayoutSidebar: React.FC<BoxProps> = ({ children, ...props }) => {
 export const Layout: React.FC<{
   posts: Post[];
   renderSidebar?: () => ReactNode;
-}> = ({ posts, renderSidebar, children }) => (
-  <Box
-    display="flex"
-    flexDirection="column"
-    height="100%"
-    maxWidth="1300"
-    marginLeft="auto"
-    marginRight="auto"
-  >
-    <PageHeader posts={posts} />
-    {typeof renderSidebar === "function" ? (
-      <Box
-        as="main"
-        display="flex"
-        flexDirection={{ base: "column", md: "row" }}
-        paddingInline={{ md: "6" }}
-      >
-        <LayoutSidebar display={{ base: "none", md: "block" }}>
-          {renderSidebar()}
-        </LayoutSidebar>
-        {children}
-      </Box>
-    ) : (
-      <Box
-        as="main"
-        display="flex"
-        flexDirection="column"
-        alignItems={{ base: "left", md: "center" }}
-        flex="1"
-        paddingInline="6"
-      >
-        {children}
-      </Box>
-    )}
-    <PageFooter />
-  </Box>
-);
+}> = ({ posts, renderSidebar = () => null, children }) => {
+  const Sidebar = renderSidebar();
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      height="100%"
+      maxWidth="1300"
+      marginLeft="auto"
+      marginRight="auto"
+    >
+      <PageHeader posts={posts} />
+      {Sidebar ? (
+        <Box
+          as="main"
+          display="flex"
+          flexDirection={{ base: "column", md: "row" }}
+          paddingInline={{ md: "6" }}
+        >
+          <LayoutSidebar display={{ base: "none", md: "block" }}>
+            {Sidebar}
+          </LayoutSidebar>
+          {children}
+        </Box>
+      ) : (
+        <Box
+          as="main"
+          display="flex"
+          flexDirection="column"
+          alignItems={{ base: "left", md: "center" }}
+          flex="1"
+          paddingInline="6"
+        >
+          {children}
+        </Box>
+      )}
+      <PageFooter />
+    </Box>
+  );
+};

--- a/src/serializePost.ts
+++ b/src/serializePost.ts
@@ -41,7 +41,6 @@ async function serializePostImpl(post: Post): Promise<{
               listElement: "ul",
               customizeTOC: (toc: ElementNode) => {
                 visit(toc, "element", (node: ElementNode | TextNode) => {
-                  console.log("visit");
                   if (isElementNode(node) && node.tagName === "nav") {
                     node.children.unshift({
                       type: "element",

--- a/src/serializePost.ts
+++ b/src/serializePost.ts
@@ -9,7 +9,22 @@ import { serialize } from "next-mdx-remote/serialize";
 import type { Post, ElementNode, TextNode } from "./types";
 import { isElementNode } from "./utils";
 
-export async function serializePost(post: Post): Promise<{
+export async function serializePost(post: Post) {
+  const { toc, serializedContent } = await serializePostImpl(post);
+  let tocRef = toc;
+  if (tocRef) {
+    const tocListElement = tocRef.children[1] as ElementNode;
+    if (tocListElement.children.length === 0) {
+      tocRef = null;
+    }
+  }
+  return {
+    serializedContent,
+    toc: tocRef,
+  };
+}
+
+async function serializePostImpl(post: Post): Promise<{
   serializedContent: MDXRemoteSerializeResult;
   toc: ElementNode | null;
 }> {


### PR DESCRIPTION
Post without a table of contents:
<img width="1965" alt="image" src="https://user-images.githubusercontent.com/8332043/188495336-87b3ff95-659e-4e34-8099-69cadd68e47c.png">

Post with table of contents for comparison:
<img width="1972" alt="image" src="https://user-images.githubusercontent.com/8332043/188495392-3bc0b753-d661-415d-849c-6a18813b21b5.png">
